### PR TITLE
normalize paths in the LZMA to use '/'

### DIFF
--- a/src/Microsoft.DotNet.Archive/IndexedArchive.cs
+++ b/src/Microsoft.DotNet.Archive/IndexedArchive.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Archive
         {
             public DestinationFileInfo(string destinationPath, string hash)
             {
-                DestinationPath = destinationPath;
+                DestinationPath = PathUtils.Normalize(destinationPath);
                 Hash = hash;
             }
 
@@ -30,9 +30,9 @@ namespace Microsoft.DotNet.Archive
         {
             public ArchiveSource(string sourceArchive, string sourceFile, string archivePath, string hash, long size)
             {
-                SourceArchive = sourceArchive;
-                SourceFile = sourceFile;
-                ArchivePath = archivePath;
+                SourceArchive = PathUtils.Normalize(sourceArchive);
+                SourceFile = PathUtils.Normalize(sourceFile);
+                ArchivePath = PathUtils.Normalize(archivePath);
                 Hash = hash;
                 Size = size;
             }
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Archive
 
         public IndexedArchive()
         { }
-        
+
         private static Stream CreateTemporaryStream()
         {
             string temp = Path.GetTempPath();
@@ -246,7 +246,7 @@ namespace Microsoft.DotNet.Archive
                 using (var archiveStream = File.Create(DestinationPath))
                 using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create))
                 {
-                    foreach(var zipSource in entries)
+                    foreach (var zipSource in entries)
                     {
                         var entry = archive.CreateEntry(zipSource.Item1, CompressionLevel.Optimal);
                         using (var entryStream = entry.Open())
@@ -400,9 +400,9 @@ namespace Microsoft.DotNet.Archive
             CheckDisposed();
             using (var fs = File.OpenRead(externalFile))
             {
-                string hash = GetHash(fs); 
+                string hash = GetHash(fs);
                 // $ prefix indicates that the file is not in the archive and path is relative to an external directory
-                _archiveFiles[hash] = new ArchiveSource(null, null, "$" + hash , hash, fs.Length);
+                _archiveFiles[hash] = new ArchiveSource(null, null, "$" + hash, hash, fs.Length);
                 _externalFiles[hash] = externalFile;
             }
         }
@@ -441,7 +441,7 @@ namespace Microsoft.DotNet.Archive
 
             using (var sourceArchive = new ZipArchive(File.OpenRead(sourceZipFile), ZipArchiveMode.Read))
             {
-                foreach(var entry in sourceArchive.Entries)
+                foreach (var entry in sourceArchive.Entries)
                 {
                     string hash = null;
                     long size = entry.Length;

--- a/src/Microsoft.DotNet.Archive/PathUtils.cs
+++ b/src/Microsoft.DotNet.Archive/PathUtils.cs
@@ -1,0 +1,9 @@
+using System.IO;
+
+namespace Microsoft.DotNet.Archive
+{
+    internal static class PathUtils
+    {
+        internal static string Normalize(string path) => path.Replace(Path.DirectorySeparatorChar, '/');
+    }
+}


### PR DESCRIPTION
Port https://github.com/aspnet/MetaPackages/pull/88 to this new repo

(Also, VS reformatted some things, hence the whitespace changes; see the [whitespace-ignored diff](https://github.com/dotnet/dotnet-cli-archiver/pull/3/files?w=1) for clearer changes)

I used a helper instead of just inlining the replacement because it seemed a little cleaner.