### PR TITLE
Add null check to ArchiveSource constructor

### DIFF
--- a/src/Microsoft.DotNet.Archive/PathUtils.cs
+++ b/src/Microsoft.DotNet.Archive/PathUtils.cs
@@ -4,6 +4,6 @@ namespace Microsoft.DotNet.Archive
 {
     internal static class PathUtils
     {
-        internal static string Normalize(string path) => path.Replace(Path.DirectorySeparatorChar, '/');
+        internal static string Normalize(string path) => path?.Replace(Path.DirectorySeparatorChar, '/');
     }
 }


### PR DESCRIPTION
I'm updating our build to use this package for our LZMA creation and I ran into this error:

```
System.NullReferenceException: Object reference not set to an instance of an object. [C:\Users\johluo\.dotnet\buildtools\korebuild\2.1.0-preview2-15723\KoreBuild.proj]
C:\gh\Universe\build\PackageArchive.targets(51,5): error MSB4018:    at Microsoft.DotNet.Archive.IndexedArchive.ArchiveSource..ctor(String sourceArchive, String sourceFile, String archivePath, String hash, Int64 size) [C:\Users\johluo\.dotnet\buildtools\korebuild\2.1.0-preview2-15723\KoreBuild.proj]
C:\gh\Universe\build\PackageArchive.targets(51,5): error MSB4018:    at Microsoft.DotNet.Archive.IndexedArchive.AddArchiveSource(String sourceArchive, String sourceFile, String destinationPath, String hash, Int64 size) [C:\Users\johluo\.dotnet\buildtools\korebuild\2.1.0-preview2-15723\KoreBuild.proj]
C:\gh\Universe\build\PackageArchive.targets(51,5): error MSB4018:    at Microsoft.DotNet.Archive.IndexedArchive.AddFile(String sourceFilePath, String destinationPath) [C:\Users\johluo\.dotnet\buildtools\korebuild\2.1.0-preview2-15723\KoreBuild.proj]
C:\gh\Universe\build\PackageArchive.targets(51,5): error MSB4018:    at Microsoft.DotNet.Archive.IndexedArchive.<>c__DisplayClass22_0.<AddDirectory>b__0(String sourceFile) [C:\Users\johluo\.dotnet\buildtools\korebuild\2.1.0-preview2-15723\KoreBuild.proj]
```

I think the reason is that sourceArchive is set to null: https://github.com/dotnet/dotnet-cli-archiver/blob/master/src/Microsoft.DotNet.Archive/IndexedArchive.cs#L472 but ArchiveSource always tries to normalize: https://github.com/dotnet/dotnet-cli-archiver/blob/master/src/Microsoft.DotNet.Archive/IndexedArchive.cs#L33.

I took a look at the version of DotNet.Archive that we are currently using in our build and it looks like it had a null check:
![image](https://user-images.githubusercontent.com/2030323/36761386-a0f6ee5a-1bd3-11e8-8418-e94efffd93c1.png)

I assume we will want to add the check to the master branch as well.