### PR TITLE
Remove trailing slashes from source directories

### DIFF
--- a/src/Microsoft.DotNet.Archive/IndexedArchive.cs
+++ b/src/Microsoft.DotNet.Archive/IndexedArchive.cs
@@ -408,12 +408,13 @@ namespace Microsoft.DotNet.Archive
         }
         public void AddDirectory(string sourceDirectory, IProgress<ProgressReport> progress, string destinationDirectory = null)
         {
-            var sourceFiles = Directory.EnumerateFiles(sourceDirectory, "*", SearchOption.AllDirectories).ToArray();
+            var sourceDirectoryTrimmed = sourceDirectory.TrimEnd(new []{ '\\', '/' });
+            var sourceFiles = Directory.EnumerateFiles(sourceDirectoryTrimmed, "*", SearchOption.AllDirectories).ToArray();
             int filesAdded = 0;
             sourceFiles.AsParallel().ForAll(sourceFile =>
                 {
                     // path relative to the destination/extracted directory to write the file
-                    string destinationRelativePath = sourceFile.Substring(sourceDirectory.Length + 1);
+                    string destinationRelativePath = sourceFile.Substring(sourceDirectoryTrimmed.Length + 1);
 
                     if (destinationDirectory != null)
                     {
@@ -431,7 +432,7 @@ namespace Microsoft.DotNet.Archive
                         AddFile(sourceFile, destinationRelativePath);
                     }
 
-                    progress.Report($"Adding {sourceDirectory}", Interlocked.Increment(ref filesAdded), sourceFiles.Length);
+                    progress.Report($"Adding {sourceDirectoryTrimmed}", Interlocked.Increment(ref filesAdded), sourceFiles.Length);
                 });
         }
 


### PR DESCRIPTION
This would avoid the issue we saw in 2.1.2 where the first letter of all the folders were missing if the directory contained a trailing slash.