### PR TITLE
Use desired branding for 3.0 previews

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -9,7 +9,7 @@
   <!-- Repo Version Information -->
   <PropertyGroup>
     <VersionBase>0.2.0</VersionBase>
-    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
 
   <!-- Repo Toolset Features -->


### PR DESCRIPTION
Should be suffix-less 'preview'